### PR TITLE
Ensure activity IDs aren't empty when firing binder tracing events

### DIFF
--- a/src/binder/bindertracing.cpp
+++ b/src/binder/bindertracing.cpp
@@ -39,6 +39,7 @@ namespace
 
         GUID activityId = GUID_NULL;
         GUID relatedActivityId = GUID_NULL;
+        bool started = false;
         {
             GCX_COOP();
             struct _gc {
@@ -66,13 +67,16 @@ namespace
                 PtrToArgSlot(&activityId),
                 PtrToArgSlot(&relatedActivityId),
             };
-            onStart.Call(args);
+            started = onStart.Call_RetBool(args);
 
             GCPROTECT_END();
         }
 
         s_RequestDepth++;
-        FireEtwAssemblyBindStart(GetClrInstanceId(), name, entryPointId, alc, &activityId, &relatedActivityId);
+        if (started)
+        {
+            FireEtwAssemblyBindStart(GetClrInstanceId(), name, entryPointId, alc, &activityId, &relatedActivityId);
+        }
 #endif // FEATURE_EVENT_TRACE
     }
 
@@ -111,6 +115,7 @@ namespace
             return;
 
         GUID activityId = GUID_NULL;
+        bool stopped = false;
         {
             GCX_COOP();
             struct _gc {
@@ -137,13 +142,17 @@ namespace
                 0,
                 PtrToArgSlot(&activityId),
             };
-            onStop.Call(args);
+            stopped = onStop.Call_RetBool(args);
 
             GCPROTECT_END();
         }
 
         s_RequestDepth--;
-        FireEtwAssemblyBindStop(GetClrInstanceId(), name, entryPointId, success, resultPath, &activityId);
+
+        if (stopped)
+        {
+            FireEtwAssemblyBindStop(GetClrInstanceId(), name, entryPointId, success, resultPath, &activityId);
+        }
 #endif // FEATURE_EVENT_TRACE
     }
 }

--- a/src/vm/metasig.h
+++ b/src/vm/metasig.h
@@ -561,8 +561,8 @@ DEFINE_METASIG_T(IM(RefGuid_OutIntPtr_RetCustomQueryInterfaceResult, r(g(GUID)) 
 
 // Activity Tracker
 DEFINE_METASIG_T(SM(RetActivityTracker, _, C(ACTIVITY_TRACKER)))
-DEFINE_METASIG_T(IM(Str_Str_Int_RefGuid_RefGuid_EventActivityOptions_RetVoid, s s i r(g(GUID)) r(g(GUID)) g(EVENT_ACTIVITY_OPTIONS), v))
-DEFINE_METASIG_T(IM(Str_Str_Int_RefGuid_RetVoid, s s i r(g(GUID)), v))
+DEFINE_METASIG_T(IM(Str_Str_Int_RefGuid_RefGuid_EventActivityOptions_RetBool, s s i r(g(GUID)) r(g(GUID)) g(EVENT_ACTIVITY_OPTIONS), F))
+DEFINE_METASIG_T(IM(Str_Str_Int_RefGuid_RetBool, s s i r(g(GUID)), F))
 
 DEFINE_METASIG_T(SM(IntPtr_AssemblyName_RetAssemblyBase, I C(ASSEMBLY_NAME), C(ASSEMBLYBASE)))
 DEFINE_METASIG_T(SM(Str_AssemblyBase_IntPtr_RetIntPtr, s C(ASSEMBLYBASE) I, I))

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1364,8 +1364,8 @@ DEFINE_FIELD_U(_condition,          ContractExceptionObject,    _Condition)
 DEFINE_CLASS(ACTIVITY_TRACKER,              Tracing,    ActivityTracker)
 DEFINE_CLASS(EVENT_ACTIVITY_OPTIONS,        Tracing,    EventActivityOptions)
 DEFINE_STATIC_PROPERTY(ACTIVITY_TRACKER,    INSTANCE,   Instance,   ActivityTracker)
-DEFINE_METHOD(ACTIVITY_TRACKER,             ON_START,   OnStart,    IM_Str_Str_Int_RefGuid_RefGuid_EventActivityOptions_RetVoid)
-DEFINE_METHOD(ACTIVITY_TRACKER,             ON_STOP,    OnStop,     IM_Str_Str_Int_RefGuid_RetVoid)
+DEFINE_METHOD(ACTIVITY_TRACKER,             ON_START,   OnStart,    IM_Str_Str_Int_RefGuid_RefGuid_EventActivityOptions_RetBool)
+DEFINE_METHOD(ACTIVITY_TRACKER,             ON_STOP,    OnStop,     IM_Str_Str_Int_RefGuid_RetBool)
 
 #ifdef FEATURE_COMINTEROP
 DEFINE_CLASS(CAUSALITY_TRACE_LEVEL, WindowsFoundationDiag,   CausalityTraceLevel)


### PR DESCRIPTION
This is but a hack, as I haven't yet discovered the root cause for the
spurious AssemblyBindStop events with an empty Activity GUID I was
getting (and causing the test to fail).

I'll continue debugging this, but for the time being, this seems like
an OK band-aid on Linux.